### PR TITLE
remove auto id param that is causing AppSync error

### DIFF
--- a/src/mutations/CreateRecipe.js
+++ b/src/mutations/CreateRecipe.js
@@ -2,13 +2,12 @@ import gql from 'graphql-tag'
  
 export default gql`
   mutation createRecipe(
-      $id: ID!,
       $name: String!,
       $ingredients: [String!],
       $instructions: [String!]
     ) {
     createRecipe(input: {
-      id: $id, name: $name, ingredients: $ingredients, instructions: $instructions, 
+      name: $name, ingredients: $ingredients, instructions: $instructions, 
     }) {
       id
       name


### PR DESCRIPTION
The recipe `id` is an autoId and should not be passed as a parameter. When it is specified as a parameter, AppSync will respond back with an error. 

Related Twitter conversation [here](https://twitter.com/ecgan/status/1018867427872948224). 